### PR TITLE
bug fix.

### DIFF
--- a/embedding/run_process.py
+++ b/embedding/run_process.py
@@ -13,8 +13,8 @@ class TokenLimitExceededError(Exception):
         self.length = length
 
 def run(params: dict, queue):
-    model = AutoModel.from_pretrained("jinaai/jina-embeddings-v3", trust_remote_code=True)
-    tokenizer = AutoTokenizer.from_pretrained("jinaai/jina-embeddings-v3", trust_remote_code=True)
+    model = AutoModel.from_pretrained("embedding/models/jina-embeddings-v3", local_files_only=True, trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained("embedding/models/jina-embeddings-v3", local_files_only=True, trust_remote_code=True)
 
     try:
         texts = params["input"]


### PR DESCRIPTION
To prevent accidentally loading jina-embedding-v3 without paying attention to the license, jina-embedding-v3 will now only be loaded if it exists as a Local File.
To use Embedding, the model file must be saved in mlx_gguf_server/embedding/models/jina-embeddings-v3.