### PR TITLE
fix: configure KV cache directory path via environment variable

### DIFF
--- a/utils/kv_cache_utils.py
+++ b/utils/kv_cache_utils.py
@@ -1,7 +1,7 @@
-from safetensors.torch import safe_open
+from safetensors import safe_open
 from fastapi import HTTPException, UploadFile
-import re
 import os
+from pathlib import Path
 import gzip
 import tempfile
 
@@ -9,23 +9,28 @@ from logging import getLogger
 
 logger = getLogger("uvicorn")
 
-def prepare_temp_dir(tmp_base_dir: str) -> str:
+def get_kv_cache_abs_path():
+    """
+    return absolute path of kv_cache directory.
+    """
+    project_root_abs_path = Path(__file__).parent.parent
+    kv_cache_abs_path = project_root_abs_path.joinpath('worker', 'kv_cache', 'data')
+    return str(kv_cache_abs_path)
+
+
+def prepare_temp_dir() -> Path:
+    tmp_base_dir = Path(os.environ["KV_CACHE_PATH"]).joinpath('tmp')
     os.makedirs(tmp_base_dir, exist_ok=True)  # Ensure the tmp base directory exists
     temp_dir = tempfile.mkdtemp(dir=tmp_base_dir)
-    return temp_dir
+    return Path(temp_dir)
 
-def validate_session_id(session_id: str) -> None:
-    """Validate session ID is a valid UUIDv4."""
-    if not re.match(r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$', session_id):
-        raise HTTPException(400, "Invalid session ID format (must be UUIDv4)")
-
-def validate_filename(session_id: str, filename: str) -> None:
+def validate_filename(filename: str) -> None:
     """Ensure filename matches expected patterns."""
-    expected = [f"{session_id}.safetensors", f"{session_id}.safetensors.gz"]
-    if filename not in expected:
-        raise HTTPException(400, f"Filename must be one of: {', '.join(expected)}")
+    suffixes = (".safetensors", ".safetensors.gz")
+    if not filename.endswith(suffixes):
+        raise HTTPException(400, f"Filename must be one of: {', '.join(suffixes)}")
 
-def __validate_safetensors(file_path: str) -> bool:
+def __validate_safetensors(file_path: Path) -> bool:
     """Check if a file is a valid safetensors file."""
     try:
         with safe_open(file_path, framework="pt") as f:
@@ -34,21 +39,20 @@ def __validate_safetensors(file_path: str) -> bool:
     except Exception:
         raise HTTPException(400, "Invalid safetensors file format")
 
-async def process_upload_file(file: UploadFile, file_path: str) -> str:
+async def process_upload_file(file: UploadFile, file_path: Path) -> Path:
     with open(file_path, "wb") as buffer:
         buffer.write(await file.read())
 
-    _, ext = os.path.splitext(file.filename)
-
     # Decompress if necessary
-    if ext == '.safetensors':
-        decompressed_path = file_path
-    elif ext == '.gz':
-        decompressed_path = os.path.splitext(file_path)[0]
+    decompressed_path = file_path
+    if file_path.suffix == '.safetensors':
+        pass
+    elif file_path.suffix == '.gz':
+        decompressed_path = Path(file_path.stem)
         with gzip.open(file_path, 'rb') as f_in:
             with open(decompressed_path, 'wb') as f_out:
                 f_out.write(f_in.read())
-        os.remove(file_path)  # Remove compressed file
+        file_path.unlink(missing_ok=True) # Remove compressed file
 
     # Validate safetensors format
     __validate_safetensors(decompressed_path)

--- a/worker/kv_cache/kv_cache_manager.py
+++ b/worker/kv_cache/kv_cache_manager.py
@@ -31,8 +31,7 @@ class KVCacheManager:
         """
         return absolute path of kv_cache directory.
         """
-        current_dir = Path(__file__).parent
-        return current_dir.joinpath(current_dir, 'data')
+        return os.environ["KV_CACHE_PATH"]
 
     def _get_cache_files_list(self):
         """
@@ -76,12 +75,16 @@ class KVCacheManager:
             cached_tokens = []
 
         # if common_len < lan(cached_tokens), cache is needed to be trimmed.
-        if prefix_len < len(cached_tokens):
+        if 0 < prefix_len and prefix_len < len(cached_tokens):
+            logger.debug(f"{prefix_len=}, {len(cached_tokens)=}. Try to trim cache file: {Path(file_path).name}")
             if can_trim_prompt_cache(cache):
                 # 2025/09/10. mlx-0.29.0 and mlx_lm-0.27.0
                 # as far as I tested, trim_len need to be add 1... (not sure why... orz)
                 trim_len = len(cached_tokens) - prefix_len +1
                 trim_prompt_cache(cache, trim_len)
+                logger.debug(f"{Path(file_path).name} was trimmed {trim_len} tokens.")
+            else:
+                logger.warning(f"Cache file {Path(file_path).name} is not able to trim.")
 
         return cache, metadata
 


### PR DESCRIPTION
- Centralize KV cache path handling using KV_CACHE_PATH environment variable
- Fix validate_filename() to correctly check for .safetensors and .safetensors.gz extensions
- Return generated cache ID in /v1/internal/model/kv_cache/import response
- Ensure consistent path resolution between API endpoints and worker processes