### PR TITLE
feature: enhance multi-stage failback approach for search kv cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,8 +56,8 @@ models/
 !models/store_model_files_here.txt
 adapters/
 whisper_stt/uploads
-!workder/kv_cache/data/.gitkeep
 worker/kv_cache/data/*
+!worker/kv_cache/data/.gitkeep
 
 # Exclude all .gitkeep file
 !**/.gitkeep

--- a/worker/kv_cache/kv_cache_manager.py
+++ b/worker/kv_cache/kv_cache_manager.py
@@ -1,6 +1,7 @@
 import os
 import time
 import json
+import logging
 from pathlib import Path
 from typing import Dict, List
 from mlx_lm.models.cache import make_prompt_cache, save_prompt_cache, load_prompt_cache, can_trim_prompt_cache, trim_prompt_cache
@@ -51,7 +52,7 @@ class KVCacheManager:
         cache_files.sort(key=lambda x: x[0], reverse=True)
         return cache_files
 
-    def _calc_common_length(self, cached_tokens, prompt_tokens):
+    def _calc_common_length(self, cached_tokens, prompt_tokens) -> int :
         """
         calculate length of common tokens between cache_tokens and prompt_tokens.
         """
@@ -65,7 +66,7 @@ class KVCacheManager:
         return common_len
     
 
-    def _load_best_match_cache(self, file_path: str, prefix_len: int):
+    def _load_best_match_cache(self, file_path: str, common_len: int):
         cache, metadata = load_prompt_cache(file_path, return_metadata=True)
 
         try:
@@ -75,12 +76,12 @@ class KVCacheManager:
             cached_tokens = []
 
         # if common_len < lan(cached_tokens), cache is needed to be trimmed.
-        if 0 < prefix_len and prefix_len < len(cached_tokens):
-            logger.debug(f"{prefix_len=}, {len(cached_tokens)=}. Try to trim cache file: {Path(file_path).name}")
+        if 0 < common_len and common_len < len(cached_tokens):
+            logger.debug(f"{common_len=}, {len(cached_tokens)=}. Try to trim cache file: {Path(file_path).name}")
             if can_trim_prompt_cache(cache):
                 # 2025/09/10. mlx-0.29.0 and mlx_lm-0.27.0
                 # as far as I tested, trim_len need to be add 1... (not sure why... orz)
-                trim_len = len(cached_tokens) - prefix_len +1
+                trim_len = len(cached_tokens) - common_len +1
                 trim_prompt_cache(cache, trim_len)
                 logger.debug(f"{Path(file_path).name} was trimmed {trim_len} tokens.")
             else:
@@ -94,7 +95,7 @@ class KVCacheManager:
 
         """
         best_match = {
-            "prefix_len": 0,
+            "common_len": 0,
             "file_path": None,
         }    
 
@@ -113,9 +114,14 @@ class KVCacheManager:
                 # Calculate common prefix length
                 common_len = self._calc_common_length(cached_tokens, prompt_tokens)
 
-                if (best_match["prefix_len"] < common_len and common_len < len(prompt_tokens)):
+                # If common tokens exist but it is shorter than cached_tokens, then cache needs to be trimmed.
+                if 0 < common_len and common_len < len(cached_tokens):
+                    if metadata.get("trimmable") and metadata["trimmable"] == "False":
+                        continue
+
+                if (best_match["common_len"] < common_len and common_len < len(prompt_tokens)):
                     best_match.update({
-                        "prefix_len": common_len,
+                        "common_len": common_len,
                         "file_path": file_path,
                     })
 
@@ -128,6 +134,11 @@ class KVCacheManager:
 
     def save_kv_cache(self, message_id: str, kv_cache: List[any], metadata: Dict):
         self.clean_kv_cache()
+        if can_trim_prompt_cache(kv_cache):
+            metadata["trimmable"] = "True"
+        else:
+            metadata["trimmable"] = "False"
+
         filepath = os.path.join(self.cache_dir, f"{message_id}.safetensors")
         logger.info(f"saving {message_id}.safetensors")
         save_prompt_cache(file_name=filepath, cache=kv_cache, metadata=metadata)
@@ -156,9 +167,56 @@ class KVCacheManager:
                 logger.info(f"deleted kv cache: {oldest_file}")
             self.clean_kv_cache()
 
-    def load_kv_cache(self, model, model_name: str, prompt_tokens: List):
+    def load_kv_cache_by_message_id(self, model_name: str, messages: List):
         """
-        Find the best matching KV cache by comparing token sequences (not message IDs)
+        Find the best matching KV cache based on message id.
+
+        Returns:
+            (cache, start_index, stats) where:
+            - cache: The KV cache to use
+            - index: The nummber of array of messages whether message_id matches.
+            - stats: loaded kv_cacshe's info (filename, cached token length, filesize, and time spent load)
+            - metadata tokens: for debugging purpose
+        """
+
+        all_metadata = self.metadata_store.get_all_metadata()
+
+        for reversed_index, message in enumerate(reversed(messages)):
+            if "meessage_id" not in message:
+                continue
+
+            expect_file_name = f'{message["message_id"]}.safetensors'
+            expect_file_path = Path(self.get_cache_dir()).joinpath(expect_file_name)
+
+            if str(expect_file_path) in all_metadata.keys():
+
+                # check model_name
+                if model_name != all_metadata[str(expect_file_path)]["model_name"]:
+                    continue
+
+                index = len(messages) - reversed_index
+                logger.info(f"kv cache hit by message_id based load_kv_cache. {str(expect_file_path)}. index = {index}.")
+
+                start_time = time.time()
+                cache, metadata = load_prompt_cache(expect_file_path, return_metadata=True)
+                load_time = time.time() - start_time
+                kv_load_stats = {"filename": expect_file_name,
+                                "size": os.stat(expect_file_path).st_size,
+                                "load_time": load_time
+                                }
+                return cache, index, kv_load_stats, json.loads(metadata["tokens"])
+
+        # No suitable cache found
+        return None, 0, {}, []
+
+    def make_new_cache(self, model):
+        dummy_stats =  {"filename": "new cache", "cached_tokens": 0, "size": 0, "load_time": 0}
+        return make_prompt_cache(model), dummy_stats
+
+
+    def load_kv_cache(self, model_name: str, prompt_tokens: List):
+        """
+        Find the best matching KV cache by comparing token sequences
 
         Returns:
             (cache, start_index, stats) where:
@@ -170,24 +228,25 @@ class KVCacheManager:
         # 1. Get metadata from metadata store
         all_metadata = self.metadata_store.get_all_metadata()
 
-        logger.debug("check all_metadata")
-        for fp, md in all_metadata.items():
-            logger.debug(f"filename = {fp}")
-            tk = json.loads(md["tokens"])
-            logger.debug(f"length of tokens={len(tk)}")
-            logger.debug(f"tokens = {tk}")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("check all_metadata")
+            for fp, md in all_metadata.items():
+                logger.debug(f"filename = {fp}")
+                tk = json.loads(md["tokens"])
+                logger.debug(f"length of tokens={len(tk)}")
+                logger.debug(f"tokens = {tk}")
 
         # find best maatch (longest match) kv cache file for prompt_tokens
         best_match = self._find_best_match_cache(model_name, all_metadata, prompt_tokens)
 
         # Process the best match
         if best_match["file_path"] is not None:
-            logger.info(f"KV cache hit! Prefix length: {best_match['prefix_len']}, "
+            logger.info(f"KV cache hit by token_based load_kv_cache. Common length: {best_match['common_len']}, "
                         f"from cache: {os.path.basename(best_match['file_path'])}")
 
             # load cache data to best_match["cache"]
             load_start_time = time.time()
-            cache, metadata = self._load_best_match_cache(best_match["file_path"], best_match["prefix_len"])
+            cache, metadata = self._load_best_match_cache(best_match["file_path"], best_match["common_len"])
             load_time = time.time() - load_start_time
             
             kv_load_stats = {"filename": os.path.basename(best_match["file_path"]),
@@ -196,10 +255,8 @@ class KVCacheManager:
                              }
 
             logger.debug(f"{kv_load_stats=}")
-            return (cache, best_match["prefix_len"], kv_load_stats)
+            return (cache, best_match["common_len"], kv_load_stats)
 
         # No suitable cache found
-        logger.info("No KV cache hit. Creating new cache.")
-        dummy_stats =  {"filename": "new cache", "cached_tokens": 0, "size": 0, "load_time": 0}
-        return make_prompt_cache(model), 0, dummy_stats
+        return None, 0, {}
 

--- a/worker/task/token_count/tokenizer_service.py
+++ b/worker/task/token_count/tokenizer_service.py
@@ -33,15 +33,15 @@ class TokenizerService:
         chatml_instruct_template="{%- set ns = namespace(found=false) -%}{%- for message in messages -%}{%- if message['role'] == 'system' -%}{%- set ns.found = true -%}{%- endif -%}{%- endfor -%}{%- for message in messages %}{%- if message['role'] == 'system' -%}{{- '<|im_start|>system\n' + message['content'].rstrip() + '<|im_end|>\n' -}}{%- else -%}{%- if message['role'] == 'user' -%}{{-'<|im_start|>user\n' + message['content'].rstrip() + '<|im_end|>\n'-}}{%- else -%}{{-'<|im_start|>assistant\n' + message['content'] + '<|im_end|>\n' -}}{%- endif -%}{%- endif -%}{%- endfor -%}{%- if add_generation_prompt -%}{{-'<|im_start|>assistant\n'-}}{%- endif -%}"
 
         try:
-            chat_prompt = tokenizer.apply_chat_template(messages, tools=tools, tokenize=False, add_generation_prompt=True)
+            chat_prompt = tokenizer.apply_chat_template(messages, tools=tools, tokenize=False, add_generation_prompt=add_generation_prompt)
         except Exception as e:
             logger.warning(f"Chat template failed (attempt 1): {str(e)}")
             try:
                 tokenizer.chat_template = tokenizer.default_chat_template
-                chat_prompt = self.tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+                chat_prompt = self.tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=add_generation_prompt)
             except Exception as e2:
                 logger.warning(f"Chat template failed (attempt 2): {str(e2)}")
-                chat_prompt = self.tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True, chat_template=chatml_instruct_template)
+                chat_prompt = self.tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=add_generation_prompt, chat_template=chatml_instruct_template)
         logger.debug(f"{chat_prompt=}")
         return chat_prompt
 


### PR DESCRIPTION
* The challenge this implementation wanted to solve
  - Some LLM models is not able to trim it's kv cache file. Especially, Qwen3-Next-80B-A3B.
  - In addition, Qwen3-Next-80B-A3B-Thinking model using asymmetric prompt.
  - As a result, the cached prompt tokens may not be a complete subset of the prompt tokens received from the user.
  - Since it is not a complete subset and cache data cannot be trimmed on a token-by-token basis, to use this model of KV cache, it is necessary to trim prompts on a non-token basis.
* Solution
  - if cache is not able to be trimmed and cached tokens are not a complete subset of user's prompt, token-based cache lookups are now considered failure.
  - if token-based cache lookups failured and apply_chat_template flag is true, (this means, the requested API endpoint was /v1/chat/completions) then fallback the cache lookup method to message-id based.
  - message-id based cache lookup (method name: "load_kv_cache_by_message_id") uses message level cache selection and prompt triming.
  - if message-id based cache lookup is failured or apply_chat_template flas is false, then give up on using kv cache.