### PR TITLE
Add configurable KV cache threshold (kv-cache-threshold)

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -17,8 +17,9 @@ class CompletionParams(BaseModel):
     logit_bias: Optional[Dict[int, float]] = None # mlx only
     repetition_penalty: Optional[float] = None    # mlx only
     repetition_context_size: Optional[int] = 20   # mlx only
-    use_kv_cache: bool = False          # mlx only
-    tools: Optional[list] = None        # mlx only
+    use_kv_cache: bool = False                    # mlx only
+    kv_cache_threshold: Optional[int] = 5000      # mlx only  
+    tools: Optional[list] = None                  # mlx only
     top_k: int = 0                      # llama-cpp only
     min_p: float = 0.05                 # llama-cpp only
     typical_p: float = 1.0              # llama-cpp only
@@ -63,6 +64,7 @@ class ModelLoadParams(BaseModel):
     repetition_context_size: Optional[int] = None
     top_p: Optional[float] = None
     use_kv_cache: Optional[bool] = None
+    kv_cache_threshold: Optional[int] = None
 
 class ProcessCleanParams(BaseModel):
     timeout: int

--- a/worker/task/load/model_loader.py
+++ b/worker/task/load/model_loader.py
@@ -119,7 +119,7 @@ class ModelLoader:
         llm_model.default_gen_params = {}
         relevant_params = [
             "temperature", "max_tokens", "logit_bias",
-            "repetition_penalty", "repetition_context_size", "top_p", "use_kv_cache"
+            "repetition_penalty", "repetition_context_size", "top_p", "use_kv_cache", "kv_cache_threshold"
         ]
 
         for param_name in relevant_params:


### PR DESCRIPTION
- Introduces a token count threshold that determines when KV Cache files are saved
- Only saves new cache files when prompt tokens exceed threshold (default: 5000)
- This prevents wasteful storage of small prompts that rarely get reused.
- "kv-cache-threshold" parameter is configurable at two levels:
  * Model load timing. (uses the set value as a default until unload the model.)
  * Per-request override